### PR TITLE
Redesign Raise for Python/SQL and add Spanish layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,25 @@ Configuracion ZMK para teclado split Corne con nice!nano v2 y nice!view displays
 
 ## Capas
 
+| # | Capa | Activacion |
+|---|------|-----------|
+| 0 | Base (Dvorak) | Default |
+| 1 | Lower (Nums + Fn) | Hold LWR |
+| 2 | Raise (Simbolos) | Hold RSE |
+| 3 | Adjust (BT + toggles) | LWR + RSE |
+| 4 | Gaming (Stardew) | Toggle desde Adjust |
+| 5 | Espanol (acentos) | Hold RALT o toggle desde Adjust |
+
 ### Base (Dvorak)
 
 ```
 | TAB       | ' " | ,   | .   |  P  |  Y  |         |  F  |  G  |  C  |  R  |  L  | BKSP |
 | LSHFT     |  A  |  O  |  E  |  U  |  I  |         |  D  |  H  |  T  |  N  |  S  |  DEL |
 | LCTRL     | : ; |  Q  |  J  |  K  |  X  |         |  B  |  M  |  W  |  V  |  Z  | ESC  |
-                    | CMD | LWR | SPC |         | ENT | RSE | ALT |
+                    | CMD | LWR | SPC |         | ENT | RSE | ESP/ALT |
 ```
+
+- **ESP/ALT (thumb derecho):** Tap = ALT, Hold = capa Espanol
 
 ### Lower (Numeros + Fn + Navegacion)
 
@@ -33,20 +44,37 @@ Configuracion ZMK para teclado split Corne con nice!nano v2 y nice!view displays
                    | CMD |     | SPC |            | ENT |     | ALT |
 ```
 
-### Raise (Simbolos)
+### Raise (Simbolos — optimizado para Python/SQL)
 
 ```
-| TAB |  !  |  @  |  #  |  $  |  %  |        |  ^  |  &  |  *  |  (  |  )  | BKSP |
-| SHF |  ?  |  -  |  [  |  (  |  :  |        |  ;  |  )  |  ]  |  +  |  =  |  `   |
-| CTRL|  ~  |  _  |  <  |  {  |  "  |        |  '  |  }  |  >  |  |  |  /  |  \   |
-               | CMD |     | SPC |        | ENT |     | ALT |
+| TAB  |  !  |  @  |  #  |  $  |  %  |        |  ^  |  &  |  *  |  ?  |  +  | BKSP |
+| SHF  |  :  |  (  |  )  |  [  |  ]  |        |  ;  |  _  |  =  |  -  |  /  |  `   |
+| CTRL |     |  {  |  }  |  <  |  >  |        |  ~  |  "  |  '  |  |  |  \  |      |
+                   | CMD |     | SPC |        | ENT |     | ALT |
 ```
+
+**Filosofia:** Mano izquierda = pares de brackets, mano derecha = simbolos sueltos.
+
+**Home row izquierda — Pares (mas usados):**
+- `:` (ring) — Python defs, dicts, slices
+- `(` `)` (middle, index) — roll natural para `()`, lo mas comun en Python/SQL
+- `[` `]` (index-stretch, pinky-stretch) — lists, indexing
+
+**Home row derecha — Simbolos sueltos:**
+- `_` (index) — snake_case, SQL columns
+- `=` (middle) — asignacion, comparacion
+- `-` (ring) — sustraccion, kwargs
+- `/` (pinky) — division, paths
+
+**Bottom izquierda — Pares secundarios:**
+- `{` `}` — dicts, f-strings, sets
+- `<` `>` — comparacion, type hints
 
 ### Adjust (LWR + RSE — Tri-layer)
 
 ```
 | BTCLR | BT1  | BT2  | BT3  | BT4  | BT5  |        |     |     |     |     |     |      |
-|       |      |      |      |      | GAME |        |     |     |     |     |     |      |
+|       |      |      |      | ESP  | GAME |        |     |     |     |     |     |      |
 |       |      |      |      |      |      |        |     |     |     |     |     |      |
                       |      |      |      |        |     |     |     |
 ```
@@ -56,6 +84,7 @@ Se activa manteniendo **LWR + RSE** al mismo tiempo (tri-layer condicional).
 - **BT1-BT5:** Seleccionar perfil Bluetooth
 - **BTCLR:** Limpiar el perfil Bluetooth actual
 - **GAME:** Toggle para entrar al modo gaming (fila 2, columna 6 izquierda)
+- **ESP:** Toggle para capa Espanol (fila 2, columna 5 izquierda)
 
 ### Gaming (Stardew Valley)
 
@@ -85,6 +114,28 @@ Layout QWERTY optimizado para Stardew Valley.
 
 **Activar:** LWR + RSE + GAME (desde capa Adjust)
 **Salir:** Presiona `tog` en el thumb derecho (posicion central)
+
+### Espanol (acentos)
+
+```
+|      |     |     |     |     |     |         |     |     |     |     |     |      |
+|      |  á  |  ó  |  é  |  ú  |  í  |         |     |     |     |  ñ  |     |      |
+|      |  ¡  |  ¿  |     |  ü  |     |         |     |     |     |     |     |      |
+                   |     |     |     |         |     |     | ### |
+```
+
+Caracteres espanoles via macros de Alt codes (Windows). Funciona en cualquier layout de Windows sin instalar software adicional.
+
+**Activar:**
+- **Hold RALT** (thumb derecho) — momentaneo, para uso rapido
+- **LWR + RSE + ESP** (desde Adjust) — toggle, para escritura prolongada en espanol
+
+**Posiciones:** Las vocales acentuadas estan en las mismas posiciones que en Dvorak (A, O, E, U, I en home row izquierda), asi que la memoria muscular es natural.
+
+- `ñ` en posicion de N (home row derecha)
+- `ü` en posicion de K (debajo de U)
+- `¡` en posicion de `: ;` (debajo de A)
+- `¿` en posicion de Q (debajo de O)
 
 ## Display
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -14,6 +14,109 @@
 };
 
 / {
+        macros {
+                // Spanish characters via Windows Alt codes
+                macro_a_acute: macro_a_acute {
+                        compatible = "zmk,behavior-macro";
+                        #binding-cells = <0>;
+                        wait-ms = <40>;
+                        tap-ms = <40>;
+                        bindings
+                                = <&macro_press &kp LALT>
+                                , <&macro_tap &kp KP_N0 &kp KP_N2 &kp KP_N2 &kp KP_N5>
+                                , <&macro_release &kp LALT>
+                                ;
+                };
+                macro_e_acute: macro_e_acute {
+                        compatible = "zmk,behavior-macro";
+                        #binding-cells = <0>;
+                        wait-ms = <40>;
+                        tap-ms = <40>;
+                        bindings
+                                = <&macro_press &kp LALT>
+                                , <&macro_tap &kp KP_N0 &kp KP_N2 &kp KP_N3 &kp KP_N3>
+                                , <&macro_release &kp LALT>
+                                ;
+                };
+                macro_i_acute: macro_i_acute {
+                        compatible = "zmk,behavior-macro";
+                        #binding-cells = <0>;
+                        wait-ms = <40>;
+                        tap-ms = <40>;
+                        bindings
+                                = <&macro_press &kp LALT>
+                                , <&macro_tap &kp KP_N0 &kp KP_N2 &kp KP_N3 &kp KP_N7>
+                                , <&macro_release &kp LALT>
+                                ;
+                };
+                macro_o_acute: macro_o_acute {
+                        compatible = "zmk,behavior-macro";
+                        #binding-cells = <0>;
+                        wait-ms = <40>;
+                        tap-ms = <40>;
+                        bindings
+                                = <&macro_press &kp LALT>
+                                , <&macro_tap &kp KP_N0 &kp KP_N2 &kp KP_N4 &kp KP_N3>
+                                , <&macro_release &kp LALT>
+                                ;
+                };
+                macro_u_acute: macro_u_acute {
+                        compatible = "zmk,behavior-macro";
+                        #binding-cells = <0>;
+                        wait-ms = <40>;
+                        tap-ms = <40>;
+                        bindings
+                                = <&macro_press &kp LALT>
+                                , <&macro_tap &kp KP_N0 &kp KP_N2 &kp KP_N5 &kp KP_N0>
+                                , <&macro_release &kp LALT>
+                                ;
+                };
+                macro_ntilde: macro_ntilde {
+                        compatible = "zmk,behavior-macro";
+                        #binding-cells = <0>;
+                        wait-ms = <40>;
+                        tap-ms = <40>;
+                        bindings
+                                = <&macro_press &kp LALT>
+                                , <&macro_tap &kp KP_N0 &kp KP_N2 &kp KP_N4 &kp KP_N1>
+                                , <&macro_release &kp LALT>
+                                ;
+                };
+                macro_u_diaeresis: macro_u_diaeresis {
+                        compatible = "zmk,behavior-macro";
+                        #binding-cells = <0>;
+                        wait-ms = <40>;
+                        tap-ms = <40>;
+                        bindings
+                                = <&macro_press &kp LALT>
+                                , <&macro_tap &kp KP_N0 &kp KP_N2 &kp KP_N5 &kp KP_N2>
+                                , <&macro_release &kp LALT>
+                                ;
+                };
+                macro_inv_question: macro_inv_question {
+                        compatible = "zmk,behavior-macro";
+                        #binding-cells = <0>;
+                        wait-ms = <40>;
+                        tap-ms = <40>;
+                        bindings
+                                = <&macro_press &kp LALT>
+                                , <&macro_tap &kp KP_N0 &kp KP_N1 &kp KP_N9 &kp KP_N1>
+                                , <&macro_release &kp LALT>
+                                ;
+                };
+                macro_inv_excl: macro_inv_excl {
+                        compatible = "zmk,behavior-macro";
+                        #binding-cells = <0>;
+                        wait-ms = <40>;
+                        tap-ms = <40>;
+                        bindings
+                                = <&macro_press &kp LALT>
+                                , <&macro_tap &kp KP_N0 &kp KP_N1 &kp KP_N6 &kp KP_N1>
+                                , <&macro_release &kp LALT>
+                                ;
+                };
+        };
+
         conditional_layers {
                 compatible = "zmk,conditional-layers";
                 adjust_layer {
@@ -30,13 +133,13 @@
 // | TAB       | ' " | ,   | .   |  P  |  Y  |         | F   |  G   |  C  |  R  |  L  | BKSP |
 // | LSHFT     |  A  |  O  |  E  |  U  |  I  |         |  D  |  H   |  T  |  N  |  S  |  DEL |
 // | LCTRL     | : ; |  Q  |  J  |  K  |  X  |         |  B  |  M   |  W  |  V  |  Z  | ESC  |
-//                     | COMMAND | LWR | SPC |         | ENT | RSE  | ALT |
+//                     | COMMAND | LWR | SPC |         | ENT | RSE  | ESP/ALT |
 
                         bindings = <
 &kp TAB    &mt SQT DOUBLE_QUOTES  &kp COMMA  &kp DOT           &kp P  &kp Y        &kp F      &kp G  &kp C     &kp R  &kp L  &kp BSPC
 &kp LSHFT  &kp A                  &kp O      &kp E             &kp U  &kp I        &kp D      &kp H  &kp T     &kp N  &kp S  &kp DEL
 &kp LCTRL  &mt COLON SEMICOLON    &kp Q      &kp J             &kp K  &kp X        &kp B      &kp M  &kp W     &kp V  &kp Z  &kp ESC
-                                              &kp LEFT_COMMAND  &mo 1  &kp SPACE    &kp ENTER  &mo 2  &kp LALT
+                                              &kp LEFT_COMMAND  &mo 1  &kp SPACE    &kp ENTER  &mo 2  &lt 5 LALT
             >;
         };
 
@@ -56,27 +159,27 @@
 
                 raise {
 // -----------------------------------------------------------------------------------------
-// |  TAB |  !  |  @  |  #  |  $  |  %  |        |  ^  |  &  |  *  |  (  |  )  | BKSP |
-// | SHF  |  ?  |  -  |  [  |  (  |  :  |        |  ;  |  )  |  ]  |  +  |  =  |  `   |
-// | CTRL |  ~  |  _  |  <  |  {  |  "  |        |  '  |  }  |  >  |  |  |  /  |  \   |
+// |  TAB |  !  |  @  |  #  |  $  |  %  |        |  ^  |  &  |  *  |  ?  |  +  | BKSP |
+// | SHF  |  :  |  (  |  )  |  [  |  ]  |        |  ;  |  _  |  =  |  -  |  /  |  `   |
+// | CTRL |     |  {  |  }  |  <  |  >  |        |  ~  |  "  |  '  |  |  |  \  |      |
 //                | COMMAND |     | SPC |        | ENT |     | ALT |
                         bindings = <
-&kp TAB    &kp EXCLAMATION  &kp AT          &kp HASH          &kp DOLLAR            &kp PERCENT          &kp CARET      &kp AMPERSAND          &kp STAR           &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp BSPC
-&kp LSHFT  &kp QUESTION     &kp MINUS       &kp LEFT_BRACKET  &kp LEFT_PARENTHESIS  &kp COLON            &kp SEMICOLON  &kp RIGHT_PARENTHESIS  &kp RIGHT_BRACKET  &kp PLUS              &kp EQUAL              &kp GRAVE
-&kp LCTRL  &kp TILDE        &kp UNDERSCORE  &kp LESS_THAN     &kp LEFT_BRACE        &kp DOUBLE_QUOTES    &kp SQT        &kp RIGHT_BRACE        &kp GREATER_THAN   &kp PIPE              &kp SLASH              &kp BACKSLASH
-                                            &kp LGUI          &trans                &kp SPACE            &kp ENTER      &trans                 &kp RALT
+&kp TAB    &kp EXCLAMATION  &kp AT                &kp HASH          &kp DOLLAR      &kp PERCENT          &kp CARET      &kp AMPERSAND      &kp STAR   &kp QUESTION  &kp PLUS       &kp BSPC
+&kp LSHFT  &kp COLON        &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp LEFT_BRACKET  &kp RIGHT_BRACKET    &kp SEMICOLON  &kp UNDERSCORE     &kp EQUAL  &kp MINUS     &kp SLASH      &kp GRAVE
+&kp LCTRL  &trans           &kp LEFT_BRACE        &kp RIGHT_BRACE   &kp LESS_THAN   &kp GREATER_THAN     &kp TILDE      &kp DOUBLE_QUOTES  &kp SQT    &kp PIPE      &kp BACKSLASH  &trans
+                                                   &kp LGUI          &trans          &kp SPACE            &kp ENTER      &trans             &kp RALT
             >;
         };
 
                 adjust {
 // -----------------------------------------------------------------------------------------
 // | BTCLR | BT1  | BT2  | BT3  | BT4  | BT5  |        |     |     |     |     |     |      |
-// |       |      |      |      |      | GAME |        |     |     |     |     |     |      |
+// |       |      |      |      | ESP  | GAME |        |     |     |     |     |     |      |
 // |       |      |      |      |      |      |        |     |     |     |     |     |      |
 //                       |      |      |      |        |     |     |     |
                         bindings = <
 &bt BT_CLR  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4    &trans  &trans  &trans  &trans  &trans  &trans
-&trans      &trans         &trans         &trans         &trans         &tog 4          &trans  &trans  &trans  &trans  &trans  &trans
+&trans      &trans         &trans         &trans         &tog 5         &tog 4          &trans  &trans  &trans  &trans  &trans  &trans
 &trans      &trans         &trans         &trans         &trans         &trans          &trans  &trans  &trans  &trans  &trans  &trans
                                          &trans         &trans         &trans          &trans  &trans  &trans
             >;
@@ -93,6 +196,20 @@
 &kp LSHFT  &kp A  &kp S  &kp D     &kp F   &kp G        &kp N6     &kp N7   &kp N8  &kp N9  &kp N0  &kp DEL
 &kp LCTRL  &kp Z  &kp X  &kp C     &kp V   &kp B        &kp M      &kp Y    &kp UP  &trans  &trans  &trans
                           &kp LALT  &trans  &kp SPACE    &kp ENTER  &tog 4   &mo 2
+            >;
+        };
+
+                espanol {
+// -----------------------------------------------------------------------------------------
+// |      |     |     |     |     |     |         |     |     |     |     |     |      |
+// |      |  á  |  ó  |  é  |  ú  |  í  |         |     |     |     |  ñ  |     |      |
+// |      |  ¡  |  ¿  |     |  ü  |     |         |     |     |     |     |     |      |
+//                    |     |     |     |         |     |     | ### |
+                        bindings = <
+&trans  &trans           &trans              &trans  &trans              &trans     &trans  &trans  &trans  &trans          &trans  &trans
+&trans  &macro_a_acute   &macro_o_acute      &macro_e_acute  &macro_u_acute  &macro_i_acute     &trans  &trans  &trans  &macro_ntilde   &trans  &trans
+&trans  &macro_inv_excl  &macro_inv_question &trans  &macro_u_diaeresis  &trans     &trans  &trans  &trans  &trans          &trans  &trans
+                                             &trans  &trans              &trans     &trans  &trans  &trans
             >;
         };
     };


### PR DESCRIPTION
## Summary
- **Raise redesigned:** Brackets paired on left hand (`:()[]` home, `{}<>` bottom), loose symbols on right (`_` `=` promoted to home row for Python/SQL frequency)
- **Spanish layer (5):** 9 Alt-code macros for á é í ó ú ñ ü ¿ ¡, vowels in Dvorak positions for natural muscle memory
- **Dual activation:** Hold RALT (momentary) or toggle from Adjust

## Test plan
- [ ] GitHub Actions build compiles without errors
- [ ] Flash both halves
- [ ] Raise: write Python code (`def func_name(arg):`, `my_list = [1, 2]`, `if x != y:`)
- [ ] Español: hold RALT + A → á, hold RALT + N → ñ
- [ ] RALT tap still sends ALT
- [ ] Gaming layer unchanged and functional
- [ ] Toggle español from Adjust (LWR + RSE + ESP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)