### PR TITLE
Move Stardew action keys (C, X) to right hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,26 +91,29 @@ Se activa manteniendo **LWR + RSE** al mismo tiempo (tri-layer condicional).
 ```
 | TAB  |  Q  |  W  |  E  |  R  |  T  |        |  1  |  2  |  3  |  4  |  5  | ESC  |
 | SHFT |  A  |  S  |  D  |  F  |  G  |        |  6  |  7  |  8  |  9  |  0  | DEL  |
-| CTRL |  Z  |  X  |  C  |  V  |  B  |        |  M  |  Y  | UP  |     |     |      |
+| CTRL |  Z  |  X  |  C  |  V  |  B  |        |  C  |  X  |  M  |  Y  | UP  |      |
                    | ALT |     | SPC |        | ENT | tog | RSE |
 ```
 
 Layout QWERTY optimizado para Stardew Valley.
 
-**Controles izquierda (movimiento + acciones):**
+**Controles izquierda (movimiento):**
 - **WASD** — Movimiento
 - **Shift** — Correr
 - **E** — Abrir menu/inventario
-- **C** — Usar herramienta
-- **X** — Interactuar/Comer
 - **F** — Diario
 - **Tab** — Cambiar toolbar
+- **C / X** — Tambien disponibles aqui (duplicados) para uso ocasional
 
-**Controles derecha (inventario + navegacion):**
+**Controles derecha (acciones + inventario):**
+- **C** — Usar herramienta (indice, fila inferior — espejo de la izquierda)
+- **X** — Interactuar/Seleccionar (medio, fila inferior)
 - **1-0** — Slots de inventario (seleccion directa)
 - **M** — Mapa
 - **Y** — Emotes
 - **ESC** — Menu/Salir
+
+**Filosofia:** Mano izquierda mueve, mano derecha selecciona/actua. Las acciones `C` y `X` estan en la fila inferior derecha en posiciones espejo a las originales QWERTY, asi que la memoria muscular se traslada naturalmente.
 
 **Activar:** LWR + RSE + GAME (desde capa Adjust)
 **Salir:** Presiona `tog` en el thumb derecho (posicion central)

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -189,13 +189,13 @@
 // -----------------------------------------------------------------------------------------
 // | TAB  |  Q  |  W  |  E  |  R  |  T  |        |  1  |  2  |  3  |  4  |  5  | ESC  |
 // | SHFT |  A  |  S  |  D  |  F  |  G  |        |  6  |  7  |  8  |  9  |  0  | DEL  |
-// | CTRL |  Z  |  X  |  C  |  V  |  B  |        |  M  |  Y  | UP  |     |     |      |
+// | CTRL |  Z  |  X  |  C  |  V  |  B  |        |  C  |  X  |  M  |  Y  | UP  |      |
 //                    | ALT |     | SPC |        | ENT | tog | RSE |
                         bindings = <
-&kp TAB    &kp Q  &kp W  &kp E     &kp R   &kp T        &kp N1     &kp N2   &kp N3  &kp N4  &kp N5  &kp ESC
-&kp LSHFT  &kp A  &kp S  &kp D     &kp F   &kp G        &kp N6     &kp N7   &kp N8  &kp N9  &kp N0  &kp DEL
-&kp LCTRL  &kp Z  &kp X  &kp C     &kp V   &kp B        &kp M      &kp Y    &kp UP  &trans  &trans  &trans
-                          &kp LALT  &trans  &kp SPACE    &kp ENTER  &tog 4   &mo 2
+&kp TAB    &kp Q  &kp W  &kp E     &kp R   &kp T        &kp N1     &kp N2  &kp N3  &kp N4  &kp N5   &kp ESC
+&kp LSHFT  &kp A  &kp S  &kp D     &kp F   &kp G        &kp N6     &kp N7  &kp N8  &kp N9  &kp N0   &kp DEL
+&kp LCTRL  &kp Z  &kp X  &kp C     &kp V   &kp B        &kp C      &kp X   &kp M   &kp Y   &kp UP   &trans
+                          &kp LALT  &trans  &kp SPACE    &kp ENTER  &tog 4  &mo 2
             >;
         };
 


### PR DESCRIPTION
## Summary
- Mueve las teclas de accion `C` (usar herramienta) y `X` (interactuar/seleccionar) a la mano derecha en la capa Gaming, en posiciones espejo (indice y medio, fila inferior).
- Desplaza `M`, `Y`, `UP` una columna a la derecha para hacer espacio.
- Mantiene `C` y `X` en la mano izquierda como duplicados, para no romper la memoria muscular en la transicion.
- Actualiza el README con la nueva distribucion y filosofia: izquierda = movimiento, derecha = acciones/inventario.

## Test plan
- [ ] Verificar que el workflow `build.yml` compila el firmware sin errores
- [ ] Descargar el artifact y flashear ambas mitades
- [ ] En Stardew Valley: confirmar que `C` y `X` en la mano derecha funcionan como usar herramienta e interactuar
- [ ] Confirmar que WASD, Shift, 1-0 y `tog` (salir de gaming) siguen funcionando

https://claude.ai/code/session_012jwhGH1dZcDUSpCJZgQAsb

---
_Generated by [Claude Code](https://claude.ai/code/session_012jwhGH1dZcDUSpCJZgQAsb)_