### PR TITLE
Fix d-key chatter and remove ESP hold from right thumb

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Configuracion ZMK para teclado split Corne con nice!nano v2 y nice!view displays
 | 2 | Raise (Simbolos) | Hold RSE |
 | 3 | Adjust (BT + toggles) | LWR + RSE |
 | 4 | Gaming (Stardew) | Toggle desde Adjust |
-| 5 | Espanol (acentos) | Hold RALT o toggle desde Adjust |
+| 5 | Espanol (acentos) | Toggle desde Adjust |
 | 6 | Menu (mouse keys) | Toggle desde Adjust o thumb derecho de Gaming |
 
 ### Base (Dvorak)
@@ -31,10 +31,8 @@ Configuracion ZMK para teclado split Corne con nice!nano v2 y nice!view displays
 | TAB       | ' " | ,   | .   |  P  |  Y  |         |  F  |  G  |  C  |  R  |  L  | BKSP |
 | LSHFT     |  A  |  O  |  E  |  U  |  I  |         |  D  |  H  |  T  |  N  |  S  |  DEL |
 | LCTRL     | : ; |  Q  |  J  |  K  |  X  |         |  B  |  M  |  W  |  V  |  Z  | ESC  |
-                    | CMD | LWR | SPC |         | ENT | RSE | ESP/ALT |
+                    | CMD | LWR | SPC |         | ENT | RSE | ALT |
 ```
-
-- **ESP/ALT (thumb derecho):** Tap = ALT, Hold = capa Espanol
 
 ### Lower (Numeros + Fn + Navegacion)
 
@@ -165,8 +163,8 @@ Stardew Valley **no soporta navegacion por teclado en menus de inventario/baules
 Caracteres espanoles via macros de Alt codes (Windows). Funciona en cualquier layout de Windows sin instalar software adicional.
 
 **Activar:**
-- **Hold RALT** (thumb derecho) — momentaneo, para uso rapido
-- **LWR + RSE + ESP** (desde Adjust) — toggle, para escritura prolongada en espanol
+- **LWR + RSE + ESP** (desde Adjust) — toggle, para escritura en espanol
+- Para volver a la base: **LWR + RSE + ESP** otra vez (toggle)
 
 **Posiciones:** Las vocales acentuadas estan en las mismas posiciones que en Dvorak (A, O, E, U, I en home row izquierda), asi que la memoria muscular es natural.
 

--- a/config/corne.conf
+++ b/config/corne.conf
@@ -9,9 +9,9 @@ CONFIG_ZMK_DISPLAY_STATUS_SCREEN_CUSTOM=y
 # Uncomment the following line to increase the keyboard's wireless range
 CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
 
-# Enable eager debouncing
-CONFIG_ZMK_KSCAN_DEBOUNCE_PRESS_MS=1
-CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=7
+# Debouncing (sube los valores si experimentas chatter / dobles taps)
+CONFIG_ZMK_KSCAN_DEBOUNCE_PRESS_MS=8
+CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=8
 
 # Bluetooth settings
 CONFIG_ZMK_BLE_EXPERIMENTAL_CONN=y

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -134,13 +134,13 @@
 // | TAB       | ' " | ,   | .   |  P  |  Y  |         | F   |  G   |  C  |  R  |  L  | BKSP |
 // | LSHFT     |  A  |  O  |  E  |  U  |  I  |         |  D  |  H   |  T  |  N  |  S  |  DEL |
 // | LCTRL     | : ; |  Q  |  J  |  K  |  X  |         |  B  |  M   |  W  |  V  |  Z  | ESC  |
-//                     | COMMAND | LWR | SPC |         | ENT | RSE  | ESP/ALT |
+//                     | COMMAND | LWR | SPC |         | ENT | RSE  |  ALT  |
 
                         bindings = <
 &kp TAB    &mt SQT DOUBLE_QUOTES  &kp COMMA  &kp DOT           &kp P  &kp Y        &kp F      &kp G  &kp C     &kp R  &kp L  &kp BSPC
 &kp LSHFT  &kp A                  &kp O      &kp E             &kp U  &kp I        &kp D      &kp H  &kp T     &kp N  &kp S  &kp DEL
 &kp LCTRL  &mt COLON SEMICOLON    &kp Q      &kp J             &kp K  &kp X        &kp B      &kp M  &kp W     &kp V  &kp Z  &kp ESC
-                                              &kp LEFT_COMMAND  &mo 1  &kp SPACE    &kp ENTER  &mo 2  &lt 5 LALT
+                                              &kp LEFT_COMMAND  &mo 1  &kp SPACE    &kp ENTER  &mo 2  &kp LALT
             >;
         };
 


### PR DESCRIPTION
## Summary
- **Fix `d` chatter:** sube debounce de 1ms/7ms a 8ms/8ms en `corne.conf`. El valor anterior era muy agresivo en press y dejaba pasar el rebote del switch, causando que `d` se registrara como `dd`. 8ms filtra chatter sin agregar latencia perceptible.
- **Quita ESP del thumb derecho:** reemplaza `&lt 5 LALT` (tap=ALT, hold=Espanol) por `&kp LALT` (solo ALT) en la capa Base. La capa Espanol queda accesible solo via toggle desde Adjust.
- Actualiza README: tabla de capas, diagrama Base, y seccion Espanol (quita "Hold RALT").

## Test plan
- [ ] Build del firmware en GitHub Actions sin errores
- [ ] Flashear y verificar que `d` ya no se registra doble
- [ ] Confirmar que el thumb derecho hace solo ALT (sin entrar a Espanol al sostener)
- [ ] Confirmar que `LWR + RSE + ESP` desde Adjust sigue toggleando la capa Espanol
- [ ] Si el chatter persiste con 8ms, subir a 10-12ms (o cambiar el switch)

https://claude.ai/code/session_012jwhGH1dZcDUSpCJZgQAsb

---
_Generated by [Claude Code](https://claude.ai/code/session_012jwhGH1dZcDUSpCJZgQAsb)_