### PR TITLE
Add PrintScreen key to Adjust layer top-right corner

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ Configuracion ZMK para teclado split Corne con nice!nano v2 y nice!view displays
 ### Adjust (LWR + RSE — Tri-layer)
 
 ```
-| BTCLR | BT1  | BT2  | BT3  | BT4  | BT5  |        |     |     |     |     |     |      |
-|       |      |      |      | ESP  | GAME |        | MNU |     |     |     |     |      |
-|       |      |      |      |      |      |        |     |     |     |     |     |      |
+| BTCLR | BT1  | BT2  | BT3  | BT4  | BT5  |        |     |     |     |     |     | PSCRN |
+|       |      |      |      | ESP  | GAME |        | MNU |     |     |     |     |       |
+|       |      |      |      |      |      |        |     |     |     |     |     |       |
                       |      |      |      |        |     |     |     |
 ```
 
@@ -85,6 +85,7 @@ Se activa manteniendo **LWR + RSE** al mismo tiempo (tri-layer condicional).
 - **GAME:** Toggle para entrar al modo gaming (fila 2, columna 6 izquierda)
 - **ESP:** Toggle para capa Espanol (fila 2, columna 5 izquierda)
 - **MNU:** Toggle para capa Menu (mouse keys, fila 2, columna 1 derecha)
+- **PSCRN:** Print Screen (fila 1, esquina superior derecha — posicion estandar de PrtSc)
 
 ### Gaming (Stardew Valley)
 

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -174,12 +174,12 @@
 
                 adjust {
 // -----------------------------------------------------------------------------------------
-// | BTCLR | BT1  | BT2  | BT3  | BT4  | BT5  |        |     |     |     |     |     |      |
-// |       |      |      |      | ESP  | GAME |        | MNU |     |     |     |     |      |
-// |       |      |      |      |      |      |        |     |     |     |     |     |      |
+// | BTCLR | BT1  | BT2  | BT3  | BT4  | BT5  |        |     |     |     |     |     | PSCRN |
+// |       |      |      |      | ESP  | GAME |        | MNU |     |     |     |     |       |
+// |       |      |      |      |      |      |        |     |     |     |     |     |       |
 //                       |      |      |      |        |     |     |     |
                         bindings = <
-&bt BT_CLR  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4    &trans  &trans  &trans  &trans  &trans  &trans
+&bt BT_CLR  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4    &trans  &trans  &trans  &trans  &trans  &kp PRINTSCREEN
 &trans      &trans         &trans         &trans         &tog 5         &tog 4          &tog 6  &trans  &trans  &trans  &trans  &trans
 &trans      &trans         &trans         &trans         &trans         &trans          &trans  &trans  &trans  &trans  &trans  &trans
                                          &trans         &trans         &trans          &trans  &trans  &trans


### PR DESCRIPTION
## Summary
- Agrega `PRINTSCREEN` en la capa Adjust, fila 1 esquina superior derecha (posicion estandar de PrtSc en teclados convencionales).
- Activacion: **LWR + RSE + PSCRN** (tecla superior derecha en mano derecha).
- Actualiza diagrama y descripcion en README.

## Test plan
- [ ] Build OK en GitHub Actions
- [ ] Flashear y verificar que `LWR + RSE + tecla superior derecha` captura un screenshot
- [ ] Confirmar que ningun otro keybind cambio en Adjust

https://claude.ai/code/session_012jwhGH1dZcDUSpCJZgQAsb

---
_Generated by [Claude Code](https://claude.ai/code/session_012jwhGH1dZcDUSpCJZgQAsb)_